### PR TITLE
Update jquery-countup.js

### DIFF
--- a/jquery-countup.js
+++ b/jquery-countup.js
@@ -30,7 +30,11 @@
 					easing: this.settings.easing,
 					step: function() {
 						$el.text(Math.ceil( this.countNum ));
-					}
+					},
+					 complete:function() {
+                                          $el.text(this.countNum)
+                                        }
+					
 				});
 			}
 		};


### PR DESCRIPTION
The number didn't animate until its reach.
Adding the exact number at the very end of the animation solves the issue.